### PR TITLE
actions/checkout from v2->v4

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -10,6 +10,6 @@ jobs:
     env:
         REACT_APP_YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Deploy react app to github pages
       uses: tanwanimohit/deploy-react-to-ghpages@v1.0.1


### PR DESCRIPTION
Updated this to hopefully stop our errors from node 12 being no longer supported by github actions